### PR TITLE
Use path list separator defined in os pkg

### DIFF
--- a/check/all_nonwindows.go
+++ b/check/all_nonwindows.go
@@ -1,9 +1,0 @@
-// Copyright 2020 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-// +build !windows
-
-package check
-
-const pathSeperator = ":"

--- a/check/all_windows.go
+++ b/check/all_windows.go
@@ -1,9 +1,0 @@
-// Copyright 2020 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-// +build windows
-
-package check
-
-const pathSeperator = ";"

--- a/check/checkpath.go
+++ b/check/checkpath.go
@@ -24,7 +24,7 @@ func (c *PathChecker) Check() (bool, bool) {
 	}
 
 	c.gopathbin = filepath.Clean(filepath.Join(gopath, "bin"))
-	paths := strings.Split(os.Getenv("PATH"), pathSeperator)
+	paths := strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))
 	for _, p := range paths {
 		if filepath.Clean(p) == c.gopathbin {
 			return true, false


### PR DESCRIPTION
Since it is already defined in the `os` package, there is no need to re-define it here.