### PR TITLE
Update Go versions: 1.13.7, 1.12.16

### DIFF
--- a/check/checkgo.go
+++ b/check/checkgo.go
@@ -11,8 +11,8 @@ import (
 )
 
 var supportedGoVersions = []string{ // TODO(jbd): Get the list from golang.org
-	"go1.12.15",
-	"go1.13.6",
+	"go1.12.16",
+	"go1.13.7",
 	"go1.14beta1",
 }
 


### PR DESCRIPTION
Update Go versions pending the fix for PR #8.