### PR TITLE
updates vscode validator and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ govalidate
 ## Installation
 
 ```
-$ go get -u github.com/rakyll/govalidate
+$ go install github.com/rakyll/govalidate@latest
 ```
 
 Or download one of the binaries and run:

--- a/check/checkvscode.go
+++ b/check/checkvscode.go
@@ -35,7 +35,7 @@ func (c *VSCodeChecker) Check() (bool, bool) {
 		if err != nil {
 			return false, false
 		}
-		if line == "ms-vscode.Go\n" {
+		if line == "golang.Go\n" {
 			return true, false
 		}
 	}

--- a/check/checkvscode.go
+++ b/check/checkvscode.go
@@ -35,7 +35,7 @@ func (c *VSCodeChecker) Check() (bool, bool) {
 		if err != nil {
 			return false, false
 		}
-		if line == "golang.Go\n" {
+		if line == "golang.go\n" {
 			return true, false
 		}
 	}


### PR DESCRIPTION
VS Code Go extension is now named `golang.go` fixes #17 
Updates install process from `go get` to `go install`